### PR TITLE
Image[alt] opacity set to 0

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -189,3 +189,6 @@ a:hover {
     font-size: 16px;
   }
 }
+.weatherType{
+  opacity: 0;
+}

--- a/js/main.js
+++ b/js/main.js
@@ -44,6 +44,7 @@ function generateHTMl(data) {
   $('#icon1').attr('src', data.current.condition.icon);
   $('.temp').text(data.current.temp_c);
   $('.weather-description').text(data.current.condition.text);
+  $('.weatherType').css('opacity', '1');
 }
 
 function click() {


### PR DESCRIPTION
Image (weather Icon) opacity set to 0 before allowing to access location.
After success -> opacity set to 1.